### PR TITLE
National multiples

### DIFF
--- a/misc-examples/national-small-multiples/charts/bigChart.js
+++ b/misc-examples/national-small-multiples/charts/bigChart.js
@@ -1,0 +1,61 @@
+Highcharts.chart("big-chart", {
+  title: {
+    text: "ME",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/bigChart.js
+++ b/misc-examples/national-small-multiples/charts/bigChart.js
@@ -1,28 +1,25 @@
 Highcharts.chart("big-chart", {
   title: {
-    text: "All States",
+    text: 'HI',
+    align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
+  },
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
+  },
+  subtitle: {
+    text: '',
     align: "left",
   },
   legend: {
-    enabled: false,
+    enabled: false
   },
-  subtitle: {
-    text: "",
-    align: "left",
-  },
-
-  yAxis: {
-    title: {
-      text: "",
-    },
-  },
-
-  xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
-  },
-
   plotOptions: {
     series: {
       label: {
@@ -31,31 +28,12 @@ Highcharts.chart("big-chart", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/bigChart.js
+++ b/misc-examples/national-small-multiples/charts/bigChart.js
@@ -1,6 +1,6 @@
 Highcharts.chart("big-chart", {
   title: {
-    text: "ME",
+    text: "All States",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart1.js
+++ b/misc-examples/national-small-multiples/charts/chart1.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart1", {
   title: {
-    text: "ME",
+    text: 'ME',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart1", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart1.js
+++ b/misc-examples/national-small-multiples/charts/chart1.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart1", {
   title: {
-    text: "Alaska",
+    text: "ME",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart1.js
+++ b/misc-examples/national-small-multiples/charts/chart1.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart1", {
+  title: {
+    text: "Alaska",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart10.js
+++ b/misc-examples/national-small-multiples/charts/chart10.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart10", {
   title: {
-    text: "MD",
+    text: 'MD',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart10", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart10.js
+++ b/misc-examples/national-small-multiples/charts/chart10.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart10", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart11.js
+++ b/misc-examples/national-small-multiples/charts/chart11.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart11", {
   title: {
-    text: "",
+    text: "NC",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart11.js
+++ b/misc-examples/national-small-multiples/charts/chart11.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart11", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart11.js
+++ b/misc-examples/national-small-multiples/charts/chart11.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart11", {
   title: {
-    text: "NC",
+    text: 'NC',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart11", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart12.js
+++ b/misc-examples/national-small-multiples/charts/chart12.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart12", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart12.js
+++ b/misc-examples/national-small-multiples/charts/chart12.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart12", {
   title: {
-    text: "FL",
+    text: 'FL',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart12", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart12.js
+++ b/misc-examples/national-small-multiples/charts/chart12.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart12", {
   title: {
-    text: "",
+    text: "FL",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart13.js
+++ b/misc-examples/national-small-multiples/charts/chart13.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart13", {
   title: {
-    text: "",
+    text: "PA",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart13.js
+++ b/misc-examples/national-small-multiples/charts/chart13.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart13", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart13.js
+++ b/misc-examples/national-small-multiples/charts/chart13.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart13", {
   title: {
-    text: "PA",
+    text: 'PA',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart13", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart14.js
+++ b/misc-examples/national-small-multiples/charts/chart14.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart14", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart14.js
+++ b/misc-examples/national-small-multiples/charts/chart14.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart14", {
   title: {
-    text: "",
+    text: "VA",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart14.js
+++ b/misc-examples/national-small-multiples/charts/chart14.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart14", {
   title: {
-    text: "VA",
+    text: 'VA',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart14", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart15.js
+++ b/misc-examples/national-small-multiples/charts/chart15.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart15", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart15.js
+++ b/misc-examples/national-small-multiples/charts/chart15.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart15", {
   title: {
-    text: "SC",
+    text: 'SC',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart15", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart15.js
+++ b/misc-examples/national-small-multiples/charts/chart15.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart15", {
   title: {
-    text: "",
+    text: "SC",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart16.js
+++ b/misc-examples/national-small-multiples/charts/chart16.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart16", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart16.js
+++ b/misc-examples/national-small-multiples/charts/chart16.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart16", {
   title: {
-    text: "",
+    text: "GA",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart16.js
+++ b/misc-examples/national-small-multiples/charts/chart16.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart16", {
   title: {
-    text: "GA",
+    text: 'GA',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart16", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart17.js
+++ b/misc-examples/national-small-multiples/charts/chart17.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart17", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart17.js
+++ b/misc-examples/national-small-multiples/charts/chart17.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart17", {
   title: {
-    text: "MI",
+    text: 'MI',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart17", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart17.js
+++ b/misc-examples/national-small-multiples/charts/chart17.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart17", {
   title: {
-    text: "",
+    text: "MI",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart18.js
+++ b/misc-examples/national-small-multiples/charts/chart18.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart18", {
   title: {
-    text: "OH",
+    text: 'OH',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart18", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart18.js
+++ b/misc-examples/national-small-multiples/charts/chart18.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart18", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart18.js
+++ b/misc-examples/national-small-multiples/charts/chart18.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart18", {
   title: {
-    text: "",
+    text: "OH",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart19.js
+++ b/misc-examples/national-small-multiples/charts/chart19.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart19", {
   title: {
-    text: "",
+    text: "WV",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart19.js
+++ b/misc-examples/national-small-multiples/charts/chart19.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart19", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart19.js
+++ b/misc-examples/national-small-multiples/charts/chart19.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart19", {
   title: {
-    text: "WV",
+    text: 'WV',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart19", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart2.js
+++ b/misc-examples/national-small-multiples/charts/chart2.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart2", {
   title: {
-    text: "",
+    text: "NH",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart2.js
+++ b/misc-examples/national-small-multiples/charts/chart2.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart2", {
   title: {
-    text: "NH",
+    text: 'NH',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart2", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
-})
+  ]
+});

--- a/misc-examples/national-small-multiples/charts/chart2.js
+++ b/misc-examples/national-small-multiples/charts/chart2.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart2", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+})

--- a/misc-examples/national-small-multiples/charts/chart20.js
+++ b/misc-examples/national-small-multiples/charts/chart20.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart20", {
   title: {
-    text: "",
+    text: "TN",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart20.js
+++ b/misc-examples/national-small-multiples/charts/chart20.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart20", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart20.js
+++ b/misc-examples/national-small-multiples/charts/chart20.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart20", {
   title: {
-    text: "TN",
+    text: 'TN',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart20", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart21.js
+++ b/misc-examples/national-small-multiples/charts/chart21.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart21", {
   title: {
-    text: "AL",
+    text: 'AL',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart21", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart21.js
+++ b/misc-examples/national-small-multiples/charts/chart21.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart21", {
   title: {
-    text: "",
+    text: "AL",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart21.js
+++ b/misc-examples/national-small-multiples/charts/chart21.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart21", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart22.js
+++ b/misc-examples/national-small-multiples/charts/chart22.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart22", {
   title: {
-    text: "WI",
+    text: 'WI',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart22", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart22.js
+++ b/misc-examples/national-small-multiples/charts/chart22.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart22", {
   title: {
-    text: "",
+    text: "WI",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart22.js
+++ b/misc-examples/national-small-multiples/charts/chart22.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart22", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart23.js
+++ b/misc-examples/national-small-multiples/charts/chart23.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart23", {
   title: {
-    text: "IN",
+    text: 'IN',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart23", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart23.js
+++ b/misc-examples/national-small-multiples/charts/chart23.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart23", {
   title: {
-    text: "",
+    text: "IN",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart23.js
+++ b/misc-examples/national-small-multiples/charts/chart23.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart23", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart24.js
+++ b/misc-examples/national-small-multiples/charts/chart24.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart24", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart24.js
+++ b/misc-examples/national-small-multiples/charts/chart24.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart24", {
   title: {
-    text: "",
+    text: "KY",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart24.js
+++ b/misc-examples/national-small-multiples/charts/chart24.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart24", {
   title: {
-    text: "KY",
+    text: 'KY',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart24", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart25.js
+++ b/misc-examples/national-small-multiples/charts/chart25.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart25", {
   title: {
-    text: "MS",
+    text: 'MS',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart25", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart25.js
+++ b/misc-examples/national-small-multiples/charts/chart25.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart25", {
   title: {
-    text: "",
+    text: "MS",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart25.js
+++ b/misc-examples/national-small-multiples/charts/chart25.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart25", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart26.js
+++ b/misc-examples/national-small-multiples/charts/chart26.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart26", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart26.js
+++ b/misc-examples/national-small-multiples/charts/chart26.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart26", {
   title: {
-    text: "MN",
+    text: 'MN',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart26", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart26.js
+++ b/misc-examples/national-small-multiples/charts/chart26.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart26", {
   title: {
-    text: "",
+    text: "MN",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart27.js
+++ b/misc-examples/national-small-multiples/charts/chart27.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart27", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart27.js
+++ b/misc-examples/national-small-multiples/charts/chart27.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart27", {
   title: {
-    text: "",
+    text: "IA",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart27.js
+++ b/misc-examples/national-small-multiples/charts/chart27.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart27", {
   title: {
-    text: "IA",
+    text: 'IA',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart27", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart28.js
+++ b/misc-examples/national-small-multiples/charts/chart28.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart28", {
   title: {
-    text: "",
+    text: "IL",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart28.js
+++ b/misc-examples/national-small-multiples/charts/chart28.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart28", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart28.js
+++ b/misc-examples/national-small-multiples/charts/chart28.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart28", {
   title: {
-    text: "IL",
+    text: 'IL',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart28", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart29.js
+++ b/misc-examples/national-small-multiples/charts/chart29.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart29", {
   title: {
-    text: "",
+    text: "MO",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart29.js
+++ b/misc-examples/national-small-multiples/charts/chart29.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart29", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart29.js
+++ b/misc-examples/national-small-multiples/charts/chart29.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart29", {
   title: {
-    text: "MO",
+    text: 'MO',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart29", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart3.js
+++ b/misc-examples/national-small-multiples/charts/chart3.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart3", {
   title: {
-    text: "RI",
+    text: 'RI',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart3", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart3.js
+++ b/misc-examples/national-small-multiples/charts/chart3.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart3", {
   title: {
-    text: "",
+    text: "RI",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart3.js
+++ b/misc-examples/national-small-multiples/charts/chart3.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart3", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart30.js
+++ b/misc-examples/national-small-multiples/charts/chart30.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart30", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart30.js
+++ b/misc-examples/national-small-multiples/charts/chart30.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart30", {
   title: {
-    text: "AR",
+    text: 'AR',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart30", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart30.js
+++ b/misc-examples/national-small-multiples/charts/chart30.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart30", {
   title: {
-    text: "",
+    text: "AR",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart31.js
+++ b/misc-examples/national-small-multiples/charts/chart31.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart31", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart31.js
+++ b/misc-examples/national-small-multiples/charts/chart31.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart31", {
   title: {
-    text: "",
+    text: "ND",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart31.js
+++ b/misc-examples/national-small-multiples/charts/chart31.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart31", {
   title: {
-    text: "ND",
+    text: 'ND',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart31", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart32.js
+++ b/misc-examples/national-small-multiples/charts/chart32.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart32", {
   title: {
-    text: "",
+    text: "SD",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart32.js
+++ b/misc-examples/national-small-multiples/charts/chart32.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart32", {
   title: {
-    text: "SD",
+    text: 'SD',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart32", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart32.js
+++ b/misc-examples/national-small-multiples/charts/chart32.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart32", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart33.js
+++ b/misc-examples/national-small-multiples/charts/chart33.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart33", {
   title: {
-    text: "",
+    text: "NE",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart33.js
+++ b/misc-examples/national-small-multiples/charts/chart33.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart33", {
   title: {
-    text: "NE",
+    text: 'NE',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart33", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart33.js
+++ b/misc-examples/national-small-multiples/charts/chart33.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart33", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart34.js
+++ b/misc-examples/national-small-multiples/charts/chart34.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart34", {
   title: {
-    text: "KS",
+    text: 'KS',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart34", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart34.js
+++ b/misc-examples/national-small-multiples/charts/chart34.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart34", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart34.js
+++ b/misc-examples/national-small-multiples/charts/chart34.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart34", {
   title: {
-    text: "",
+    text: "KS",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart35.js
+++ b/misc-examples/national-small-multiples/charts/chart35.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart35", {
   title: {
-    text: "",
+    text: "LA",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart35.js
+++ b/misc-examples/national-small-multiples/charts/chart35.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart35", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart35.js
+++ b/misc-examples/national-small-multiples/charts/chart35.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart35", {
   title: {
-    text: "LA",
+    text: 'LA',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart35", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart36.js
+++ b/misc-examples/national-small-multiples/charts/chart36.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart36", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart36.js
+++ b/misc-examples/national-small-multiples/charts/chart36.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart36", {
   title: {
-    text: "TX 36",
+    text: 'TX',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart36", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart36.js
+++ b/misc-examples/national-small-multiples/charts/chart36.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart36", {
   title: {
-    text: "",
+    text: "TX 36",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart37.js
+++ b/misc-examples/national-small-multiples/charts/chart37.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart37", {
   title: {
-    text: "",
+    text: "MT",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart37.js
+++ b/misc-examples/national-small-multiples/charts/chart37.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart37", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart37.js
+++ b/misc-examples/national-small-multiples/charts/chart37.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart37", {
   title: {
-    text: "MT",
+    text: 'MT',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart37", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart38.js
+++ b/misc-examples/national-small-multiples/charts/chart38.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart38", {
   title: {
-    text: "",
+    text: "WY",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart38.js
+++ b/misc-examples/national-small-multiples/charts/chart38.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart38", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart38.js
+++ b/misc-examples/national-small-multiples/charts/chart38.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart38", {
   title: {
-    text: "WY",
+    text: 'WY',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart38", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart39.js
+++ b/misc-examples/national-small-multiples/charts/chart39.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart39", {
   title: {
-    text: "",
+    text: "CO",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart39.js
+++ b/misc-examples/national-small-multiples/charts/chart39.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart39", {
   title: {
-    text: "CO",
+    text: 'CO',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart39", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart39.js
+++ b/misc-examples/national-small-multiples/charts/chart39.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart39", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart4.js
+++ b/misc-examples/national-small-multiples/charts/chart4.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart4", {
   title: {
-    text: "VT",
+    text: 'VT',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart4", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart4.js
+++ b/misc-examples/national-small-multiples/charts/chart4.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart4", {
   title: {
-    text: "",
+    text: "VT",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart4.js
+++ b/misc-examples/national-small-multiples/charts/chart4.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart4", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart40.js
+++ b/misc-examples/national-small-multiples/charts/chart40.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart40", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart40.js
+++ b/misc-examples/national-small-multiples/charts/chart40.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart40", {
   title: {
-    text: "",
+    text: "NM",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart40.js
+++ b/misc-examples/national-small-multiples/charts/chart40.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart40", {
   title: {
-    text: "NM",
+    text: 'NM',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart40", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart41.js
+++ b/misc-examples/national-small-multiples/charts/chart41.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart41", {
   title: {
-    text: "OK",
+    text: 'OK',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart41", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart41.js
+++ b/misc-examples/national-small-multiples/charts/chart41.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart41", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart41.js
+++ b/misc-examples/national-small-multiples/charts/chart41.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart41", {
   title: {
-    text: "",
+    text: "OK",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart42.js
+++ b/misc-examples/national-small-multiples/charts/chart42.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart42", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart42.js
+++ b/misc-examples/national-small-multiples/charts/chart42.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart42", {
   title: {
-    text: "",
+    text: "ID",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart42.js
+++ b/misc-examples/national-small-multiples/charts/chart42.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart42", {
   title: {
-    text: "ID",
+    text: 'ID',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart42", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart43.js
+++ b/misc-examples/national-small-multiples/charts/chart43.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart43", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart43.js
+++ b/misc-examples/national-small-multiples/charts/chart43.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart43", {
   title: {
-    text: "UT",
+    text: 'UT',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart43", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart43.js
+++ b/misc-examples/national-small-multiples/charts/chart43.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart43", {
   title: {
-    text: "",
+    text: "UT",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart44.js
+++ b/misc-examples/national-small-multiples/charts/chart44.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart44", {
   title: {
-    text: "",
+    text: "NV",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart44.js
+++ b/misc-examples/national-small-multiples/charts/chart44.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart44", {
   title: {
-    text: "NV",
+    text: 'NV',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart44", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart44.js
+++ b/misc-examples/national-small-multiples/charts/chart44.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart44", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart45.js
+++ b/misc-examples/national-small-multiples/charts/chart45.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart45", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart45.js
+++ b/misc-examples/national-small-multiples/charts/chart45.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart45", {
   title: {
-    text: "AZ",
+    text: 'AZ',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart45", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart45.js
+++ b/misc-examples/national-small-multiples/charts/chart45.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart45", {
   title: {
-    text: "",
+    text: "AZ",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart46.js
+++ b/misc-examples/national-small-multiples/charts/chart46.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart46", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart46.js
+++ b/misc-examples/national-small-multiples/charts/chart46.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart46", {
   title: {
-    text: "",
+    text: "WA",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart46.js
+++ b/misc-examples/national-small-multiples/charts/chart46.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart46", {
   title: {
-    text: "WA",
+    text: 'WA',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart46", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart47.js
+++ b/misc-examples/national-small-multiples/charts/chart47.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart47", {
   title: {
-    text: "",
+    text: "OR",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart47.js
+++ b/misc-examples/national-small-multiples/charts/chart47.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart47", {
   title: {
-    text: "OR",
+    text: 'OR',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart47", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart47.js
+++ b/misc-examples/national-small-multiples/charts/chart47.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart47", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart48.js
+++ b/misc-examples/national-small-multiples/charts/chart48.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart48", {
   title: {
-    text: "",
+    text: "CA",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart48.js
+++ b/misc-examples/national-small-multiples/charts/chart48.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart48", {
   title: {
-    text: "CA",
+    text: 'CA',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart48", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart48.js
+++ b/misc-examples/national-small-multiples/charts/chart48.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart48", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart49.js
+++ b/misc-examples/national-small-multiples/charts/chart49.js
@@ -1,28 +1,32 @@
 Highcharts.chart("chart49", {
   title: {
-    text: "AK",
-    align: "left",
+    text: 'Alaska',
+    align: "center",
+    style: {
+      fontSize: '16px',
+      fontWeight: 'normal',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +35,13 @@ Highcharts.chart("chart49", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart49.js
+++ b/misc-examples/national-small-multiples/charts/chart49.js
@@ -1,6 +1,6 @@
-Highcharts.chart("chart10", {
+Highcharts.chart("chart49", {
   title: {
-    text: "MD",
+    text: "AK",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart5.js
+++ b/misc-examples/national-small-multiples/charts/chart5.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart5", {
   title: {
-    text: "MA",
+    text: 'MA',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart5", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart5.js
+++ b/misc-examples/national-small-multiples/charts/chart5.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart5", {
   title: {
-    text: "",
+    text: "MA",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart5.js
+++ b/misc-examples/national-small-multiples/charts/chart5.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart5", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart50.js
+++ b/misc-examples/national-small-multiples/charts/chart50.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart50", {
   title: {
-    text: "HI",
+    text: 'HI',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart50", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart50.js
+++ b/misc-examples/national-small-multiples/charts/chart50.js
@@ -1,6 +1,6 @@
-Highcharts.chart("chart10", {
+Highcharts.chart("chart50", {
   title: {
-    text: "MD",
+    text: "HI",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart6.js
+++ b/misc-examples/national-small-multiples/charts/chart6.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart6", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart6.js
+++ b/misc-examples/national-small-multiples/charts/chart6.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart6", {
   title: {
-    text: "",
+    text: "CT",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart6.js
+++ b/misc-examples/national-small-multiples/charts/chart6.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart6", {
   title: {
-    text: "CT",
+    text: 'CT',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart6", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart7.js
+++ b/misc-examples/national-small-multiples/charts/chart7.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart7", {
   title: {
-    text: "",
+    text: "DE",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart7.js
+++ b/misc-examples/national-small-multiples/charts/chart7.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart7", {
   title: {
-    text: "DE",
+    text: 'DE',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart7", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart7.js
+++ b/misc-examples/national-small-multiples/charts/chart7.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart7", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart8.js
+++ b/misc-examples/national-small-multiples/charts/chart8.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart8", {
   title: {
-    text: "",
+    text: "NY",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart8.js
+++ b/misc-examples/national-small-multiples/charts/chart8.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart8", {
   title: {
-    text: "NY",
+    text: 'NY',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart8", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart8.js
+++ b/misc-examples/national-small-multiples/charts/chart8.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart8", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/charts/chart9.js
+++ b/misc-examples/national-small-multiples/charts/chart9.js
@@ -1,28 +1,31 @@
 Highcharts.chart("chart9", {
   title: {
-    text: "NJ",
+    text: 'NJ',
     align: "left",
+    style: {
+      fontSize: '14px',
+      color: '#000'
+    }
   },
-  legend: {
-    enabled: false,
+  chart: {
+    backgroundColor: '#fff'
+  },
+  credits: {
+    enabled: false
   },
   subtitle: {
-    text: "",
+    text: '',
     align: "left",
   },
-
   yAxis: {
-    title: {
-      text: "",
-    },
+    visible: false
   },
-
   xAxis: {
-    accessibility: {
-      rangeDescription: "Range: 2010 to 2022",
-    },
+    visible: false
   },
-
+  legend: {
+    enabled: false
+  },
   plotOptions: {
     series: {
       label: {
@@ -31,31 +34,13 @@ Highcharts.chart("chart9", {
       pointStart: 2010,
     },
   },
-
   series: [
     {
-      name: "",
-      data: [40, 48, 65, 82, 33, 28, 67],
+      name: "Installation & Developers",
+      data: [
+        43934, 48656, 65165, 81827, 112143, 142383, 171533, 165174, 155157,
+        161454, 154610, 168960, 171558,
+      ],
     },
-  ],
-
-  credits: {
-    enabled: false,
-  },
-  responsive: {
-    rules: [
-      {
-        condition: {
-          maxWidth: 500,
-        },
-        chartOptions: {
-          legend: {
-            layout: "horizontal",
-            align: "center",
-            verticalAlign: "bottom",
-          },
-        },
-      },
-    ],
-  },
+  ]
 });

--- a/misc-examples/national-small-multiples/charts/chart9.js
+++ b/misc-examples/national-small-multiples/charts/chart9.js
@@ -1,6 +1,6 @@
 Highcharts.chart("chart9", {
   title: {
-    text: "",
+    text: "NJ",
     align: "left",
   },
   legend: {

--- a/misc-examples/national-small-multiples/charts/chart9.js
+++ b/misc-examples/national-small-multiples/charts/chart9.js
@@ -1,0 +1,61 @@
+Highcharts.chart("chart9", {
+  title: {
+    text: "",
+    align: "left",
+  },
+  legend: {
+    enabled: false,
+  },
+  subtitle: {
+    text: "",
+    align: "left",
+  },
+
+  yAxis: {
+    title: {
+      text: "",
+    },
+  },
+
+  xAxis: {
+    accessibility: {
+      rangeDescription: "Range: 2010 to 2022",
+    },
+  },
+
+  plotOptions: {
+    series: {
+      label: {
+        connectorAllowed: false,
+      },
+      pointStart: 2010,
+    },
+  },
+
+  series: [
+    {
+      name: "",
+      data: [40, 48, 65, 82, 33, 28, 67],
+    },
+  ],
+
+  credits: {
+    enabled: false,
+  },
+  responsive: {
+    rules: [
+      {
+        condition: {
+          maxWidth: 500,
+        },
+        chartOptions: {
+          legend: {
+            layout: "horizontal",
+            align: "center",
+            verticalAlign: "bottom",
+          },
+        },
+      },
+    ],
+  },
+});

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -273,7 +273,7 @@
         // Show the big chart with a short delay for smoothness
         setTimeout(() => {
           bigChart.classList.add('show');
-        }, 500); // match the animation delay
+        }, 0.1); // match the animation delay
 
         Object.keys(squarePositions).forEach(chartId => {
           const chartEl = document.getElementById(chartId);

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -249,6 +249,12 @@
 
       moveAllBtn.addEventListener('click', () => {
         console.log("Moving All Charts");
+
+        // Show the big chart with a short delay for smoothness
+        setTimeout(() => {
+          bigChart.classList.add('show');
+        }, 500); // match the animation delay
+        
         Object.keys(squarePositions).forEach(chartId => {
           const chartEl = document.getElementById(chartId);
           if (!chartEl) return;

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -29,6 +29,7 @@
         width: 100%;
         max-width: 1200px;
         margin: auto;
+        position: relative;
       }
 
       .grid.tight {
@@ -37,7 +38,8 @@
 
       .chart {
         width: 100%;
-        aspect-ratio: 1/1;;
+        aspect-ratio: 1/1;
+        ;
         background: #fff;
         color: white;
         display: flex;
@@ -62,6 +64,7 @@
         left: 0;
         width: 100%;
         height: 100%;
+        aspect-ratio: 12/8;
         background: white;
         border: 2px solid #ccc;
         display: flex;
@@ -80,6 +83,7 @@
         pointer-events: auto;
         transition: opacity 0.5s ease-in-out;
         z-index: 2;
+        outline: 1px solid red;
       }
 
       button {
@@ -88,9 +92,6 @@
         font-size: 1rem;
         cursor: pointer;
       }
-
-
-      
     </style>
   </head>
 
@@ -233,6 +234,7 @@
     <script src="charts/chart48.js"></script>
     <script src="charts/chart49.js"></script>
     <script src="charts/chart50.js"></script>
+    <script src="charts/bigChart.js"></script>
 
     <script src="bigchart.js"></script>
 

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rotate and Merge Charts</title>
+    <link rel="stylesheet" href="national-squares.css" />
     <style>
       * {
         box-sizing: border-box;
@@ -20,22 +21,14 @@
         overflow-x: hidden;
       }
 
-      /* .grid {
-        display: grid;
-        grid-template-columns: repeat(2, 200px);
-        gap: 1rem;
-        position: relative;
-        transition: gap 0.8s ease-in-out;
-      } */
       .grid {
-        margin: 30rem auto 0 auto;
-      
         display: grid;
-        grid-template-columns: repeat(11, 60px);
-        /* adjust size as needed */
-        grid-template-rows: repeat(8, 60px);
-        gap: 4.5rem;
-        position: relative;
+        grid-template-columns: repeat(12, 1fr);
+        grid-template-rows: repeat(8, 1fr);
+        gap: 0.5vw;
+        width: 100%;
+        max-width: 1200px;
+        margin: auto;
       }
 
       .grid.tight {
@@ -43,8 +36,8 @@
       }
 
       .chart {
-        width: 125px;
-        height: 125px;
+        width: 100%;
+        aspect-ratio: 1/1;;
         background: #fff;
         color: white;
         display: flex;
@@ -55,6 +48,7 @@
         transform-origin: center;
         position: relative;
         z-index: 2;
+        font-size: 0.9rem;
 
       }
 
@@ -96,8 +90,6 @@
       }
 
 
-      /* UNITED STATES LAYOUT */
-      #chart1 { grid-column: 1; grid-row: 1;} /* Alaska*/
       
     </style>
   </head>
@@ -153,6 +145,8 @@
       <div class="chart" id="chart46">Chart 46</div>
       <div class="chart" id="chart47">Chart 47</div>
       <div class="chart" id="chart48">Chart 48</div>
+      <div class="chart" id="chart49">Chart 49</div>
+      <div class="chart" id="chart50">Chart 50</div>
 
       <div id="big-chart">Big Chart</div>
     </div>
@@ -237,6 +231,8 @@
     <script src="charts/chart46.js"></script>
     <script src="charts/chart47.js"></script>
     <script src="charts/chart48.js"></script>
+    <script src="charts/chart49.js"></script>
+    <script src="charts/chart50.js"></script>
 
     <script src="bigchart.js"></script>
 

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Rotate and Merge Charts</title>
     <link rel="stylesheet" href="national-squares.css" />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+
     <style>
       * {
         box-sizing: border-box;
@@ -107,58 +110,156 @@
   <body>
 
     <div class="grid" id="chartGrid">
-      <div class="chart" id="chart1">Chart 1</div>
-      <div class="chart" id="chart2">Chart 2</div>
-      <div class="chart" id="chart3">Chart 3</div>
-      <div class="chart" id="chart4">Chart 4</div>
-      <div class="chart" id="chart5">Chart 5</div>
-      <div class="chart" id="chart6">Chart 6</div>
-      <div class="chart" id="chart7">Chart 7</div>
-      <div class="chart" id="chart8">Chart 8</div>
-      <div class="chart" id="chart9">Chart 9</div>
-      <div class="chart" id="chart10">Chart 10</div>
-      <div class="chart" id="chart11">Chart 11</div>
-      <div class="chart" id="chart12">Chart 12</div>
-      <div class="chart" id="chart13">Chart 13</div>
-      <div class="chart" id="chart14">Chart 14</div>
-      <div class="chart" id="chart15">Chart 15</div>
-      <div class="chart" id="chart16">Chart 16</div>
-      <div class="chart" id="chart17">Chart 17</div>
-      <div class="chart" id="chart18">Chart 18</div>
-      <div class="chart" id="chart19">Chart 19</div>
-      <div class="chart" id="chart20">Chart 20</div>
-      <div class="chart" id="chart21">Chart 21</div>
-      <div class="chart" id="chart22">Chart 22</div>
-      <div class="chart" id="chart23">Chart 23</div>
-      <div class="chart" id="chart24">Chart 24</div>
-      <div class="chart" id="chart25">Chart 25</div>
-      <div class="chart" id="chart26">Chart 26</div>
-      <div class="chart" id="chart27">Chart 27</div>
-      <div class="chart" id="chart28">Chart 28</div>
-      <div class="chart" id="chart29">Chart 29</div>
-      <div class="chart" id="chart30">Chart 30</div>
-      <div class="chart" id="chart31">Chart 31</div>
-      <div class="chart" id="chart32">Chart 32</div>
-      <div class="chart" id="chart33">Chart 33</div>
-      <div class="chart" id="chart34">Chart 34</div>
-      <div class="chart" id="chart35">Chart 35</div>
-      <div class="chart" id="chart36">Chart 36</div>
-      <div class="chart" id="chart37">Chart 37</div>
-      <div class="chart" id="chart38">Chart 38</div>
-      <div class="chart" id="chart39">Chart 39</div>
-      <div class="chart" id="chart40">Chart 40</div>
-      <div class="chart" id="chart41">Chart 41</div>
-      <div class="chart" id="chart42">Chart 42</div>
-      <div class="chart" id="chart43">Chart 43</div>
-      <div class="chart" id="chart44">Chart 44</div>
-      <div class="chart" id="chart45">Chart 45</div>
-      <div class="chart" id="chart46">Chart 46</div>
-      <div class="chart" id="chart47">Chart 47</div>
-      <div class="chart" id="chart48">Chart 48</div>
+      <div class="chart" id="chart1">
+        <div class="chart-inner">Chart 1</div>
+      </div>
+      <div class="chart" id="chart2">
+        <div class="chart-inner">Chart 2</div>
+      </div>
+      <div class="chart" id="chart3">
+        <div class="chart-inner">Chart 3</div>
+      </div>
+      <div class="chart" id="chart4">
+        <div class="chart-inner">Chart 4</div>
+      </div>
+      <div class="chart" id="chart5">
+        <div class="chart-inner">Chart 5</div>
+      </div>
+      <div class="chart" id="chart6">
+        <div class="chart-inner">Chart 6</div>
+      </div>
+      <div class="chart" id="chart7">
+        <div class="chart-inner">Chart 7</div>
+      </div>
+      <div class="chart" id="chart8">
+        <div class="chart-inner">Chart 8</div>
+      </div>
+      <div class="chart" id="chart9">
+        <div class="chart-inner">Chart 9</div>
+      </div>
+      <div class="chart" id="chart10">
+        <div class="chart-inner">Chart 10</div>
+      </div>
+      <div class="chart" id="chart11">
+        <div class="chart-inner">Chart 11</div>
+      </div>
+      <div class="chart" id="chart12">
+        <div class="chart-inner">Chart 12</div>
+      </div>
+      <div class="chart" id="chart13">
+        <div class="chart-inner">Chart 13</div>
+      </div>
+      <div class="chart" id="chart14">
+        <div class="chart-inner">Chart 14</div>
+      </div>
+      <div class="chart" id="chart15">
+        <div class="chart-inner">Chart 15</div>
+      </div>
+      <div class="chart" id="chart16">
+        <div class="chart-inner">Chart 16</div>
+      </div>
+      <div class="chart" id="chart17">
+        <div class="chart-inner">Chart 17</div>
+      </div>
+      <div class="chart" id="chart18">
+        <div class="chart-inner">Chart 18</div>
+      </div>
+      <div class="chart" id="chart19">
+        <div class="chart-inner">Chart 19</div>
+      </div>
+      <div class="chart" id="chart20">
+        <div class="chart-inner">Chart 20</div>
+      </div>
+      <div class="chart" id="chart21">
+        <div class="chart-inner">chart 21</div>
+      </div>
+      <div class="chart" id="chart22">
+        <div class="chart-inner">chart 22</div>
+      </div>
+      <div class="chart" id="chart23">
+        <div class="chart-inner">chart 23</div>
+      </div>
+      <div class="chart" id="chart24">
+        <div class="chart-inner">chart 24</div>
+      </div>
+      <div class="chart" id="chart25">
+        <div class="chart-inner">chart 25</div>
+      </div>
+      <div class="chart" id="chart26">
+        <div class="chart-inner">chart 26</div>
+      </div>
+      <div class="chart" id="chart27">
+        <div class="chart-inner">chart 27</div>
+      </div>
+      <div class="chart" id="chart28">
+        <div class="chart-inner">Chart 28</div>
+      </div>
+      <div class="chart" id="chart29">
+        <div class="chart-inner">Chart 29</div>
+      </div>
+      <div class="chart" id="chart30">
+        <div class="chart-inner">Chart 30</div>
+      </div>
+      <div class="chart" id="chart31">
+        <div class="chart-inner">Chart 31</div>
+      </div>
+      <div class="chart" id="chart32">
+        <div class="chart-inner">Chart 32</div>
+      </div>
+      <div class="chart" id="chart33">
+        <div class="chart-inner">Chart 33</div>
+      </div>
+      <div class="chart" id="chart34">
+        <div class="chart-inner">Chart 34</div>
+      </div>
+      <div class="chart" id="chart35">
+        <div class="chart-inner">Chart 35</div>
+      </div>
+      <div class="chart" id="chart36">
+        <div class="chart-inner">Chart 36</div>
+      </div>
+      <div class="chart" id="chart37">
+        <div class="chart-inner">Chart 37</div>
+      </div>
+      <div class="chart" id="chart38">
+        <div class="chart-inner">Chart 38</div>
+      </div>
+      <div class="chart" id="chart39">
+        <div class="chart-inner">Chart 39</div>
+      </div>
+      <div class="chart" id="chart40">
+        <div class="chart-inner">Chart 40</div>
+      </div>
+      <div class="chart" id="chart41">
+        <div class="chart-inner">Chart 41</div>
+      </div>
+      <div class="chart" id="chart42">
+        <div class="chart-inner">Chart 42</div>
+      </div>
+      <div class="chart" id="chart43">
+        <div class="chart-inner">Chart 43</div>
+      </div>
+      <div class="chart" id="chart44">
+        <div class="chart-inner">Chart 44</div>
+      </div>
+      <div class="chart" id="chart45">
+        <div class="chart-inner">Chart 45</div>
+      </div>
+      <div class="chart" id="chart46">
+        <div class="chart-inner">Chart 46</div>
+      </div>
+      <div class="chart" id="chart47">
+        <div class="chart-inner">Chart 47</div>
+      </div>
+      <div class="chart" id="chart48">
+        <div class="chart-inner">Chart 48</div>
+      </div>
       <div class="chart" id="chart49">
         <div class="chart-inner">Chart 49</div>
       </div>
-      <div class="chart" id="chart50">Chart 50</div>
+      <div class="chart" id="chart50">
+        <div class="chart-inner">Chart 50</div>
+      </div>
 
       <div id="big-chart">Big Chart</div>
     </div>
@@ -293,36 +394,29 @@
         const targetLeft = (toCol - 1) * cellWidth;
         const targetTop = (toRow - 1) * cellHeight;
 
-        const dx = targetLeft - currentLeft;
-        const dy = targetTop - currentTop;
+        // Animate to target
+        gsap.to(chartEl, {
+          duration: 0.6,
+          x: targetLeft - currentLeft,
+          y: targetTop - currentTop,
+          ease: "power2.out",
+          onComplete: () => {
+            // Snap back into grid
+            chartEl.style.transition = "";
+            chartEl.style.transform = "";
+            chartEl.style.position = "";
+            chartEl.style.top = "";
+            chartEl.style.left = "";
+            chartEl.style.width = "";
+            chartEl.style.height = "";
+            chartEl.style.zIndex = "";
 
-        // Fix position temporarily
-        chartEl.style.position = "absolute";
-        chartEl.style.top = `${ currentTop }px`;
-        chartEl.style.left = `${ currentLeft }px`;
-        chartEl.style.width = `${ chartRect.width }px`;
-        chartEl.style.height = `${ chartRect.height }px`;
-        chartEl.style.transition = "transform 0.6s ease";
-        chartEl.style.zIndex = 10; // Make sure it's above others while animating
-
-        // Animate movement
-        chartEl.style.transform = `translate(${ dx }px, ${ dy }px)`;
-
-        // After animation, snap back into grid
-        setTimeout(() => {
-          chartEl.style.transition = "";
-          chartEl.style.transform = "";
-          chartEl.style.position = "";
-          chartEl.style.top = "";
-          chartEl.style.left = "";
-          chartEl.style.width = "";
-          chartEl.style.height = "";
-          chartEl.style.zIndex = "";
-
-          chartEl.style.gridColumnStart = toCol;
-          chartEl.style.gridRowStart = toRow;
-        }, 650); // match transition duration
+            chartEl.style.gridColumnStart = toCol;
+            chartEl.style.gridRowStart = toRow;
+          }
+        });
       }
+
 
     </script>
     <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rotate and Merge Charts</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        font-family: sans-serif;
+        background: #f5f5f5;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 2rem;
+        overflow-x: hidden;
+      }
+
+      /* .grid {
+        display: grid;
+        grid-template-columns: repeat(2, 200px);
+        gap: 1rem;
+        position: relative;
+        transition: gap 0.8s ease-in-out;
+      } */
+      .grid {
+        margin: 30rem auto 0 auto;
+      
+        display: grid;
+        grid-template-columns: repeat(11, 60px);
+        /* adjust size as needed */
+        grid-template-rows: repeat(8, 60px);
+        gap: 4.5rem;
+        position: relative;
+      }
+
+      .grid.tight {
+        gap: 0;
+      }
+
+      .chart {
+        width: 125px;
+        height: 125px;
+        background: #fff;
+        color: white;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.5rem;
+        transition: transform 0.8s ease-in-out;
+        transform-origin: center;
+        position: relative;
+        z-index: 2;
+
+      }
+
+      .rotate .chart {
+        transform: rotate(90deg);
+      }
+
+      #big-chart {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: white;
+        border: 2px solid #ccc;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        visibility: hidden;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s ease-in-out, visibility 0s linear 0.2s;
+        z-index: 1;
+      }
+
+      #big-chart.show {
+        visibility: visible;
+        opacity: 1;
+        pointer-events: auto;
+        transition: opacity 0.5s ease-in-out;
+        z-index: 2;
+      }
+
+      button {
+        margin-top: 2rem;
+        padding: 0.5rem 1rem;
+        font-size: 1rem;
+        cursor: pointer;
+      }
+
+
+      /* UNITED STATES LAYOUT */
+      #chart1 { grid-column: 1; grid-row: 1;} /* Alaska*/
+      
+    </style>
+  </head>
+
+  <body>
+
+    <div class="grid" id="chartGrid">
+      <div class="chart" id="chart1">Chart 1</div>
+      <div class="chart" id="chart2">Chart 2</div>
+      <div class="chart" id="chart3">Chart 3</div>
+      <div class="chart" id="chart4">Chart 4</div>
+      <div class="chart" id="chart5">Chart 5</div>
+      <div class="chart" id="chart6">Chart 6</div>
+      <div class="chart" id="chart7">Chart 7</div>
+      <div class="chart" id="chart8">Chart 8</div>
+      <div class="chart" id="chart9">Chart 9</div>
+      <div class="chart" id="chart10">Chart 10</div>
+      <div class="chart" id="chart11">Chart 11</div>
+      <div class="chart" id="chart12">Chart 12</div>
+      <div class="chart" id="chart13">Chart 13</div>
+      <div class="chart" id="chart14">Chart 14</div>
+      <div class="chart" id="chart15">Chart 15</div>
+      <div class="chart" id="chart16">Chart 16</div>
+      <div class="chart" id="chart17">Chart 17</div>
+      <div class="chart" id="chart18">Chart 18</div>
+      <div class="chart" id="chart19">Chart 19</div>
+      <div class="chart" id="chart20">Chart 20</div>
+      <div class="chart" id="chart21">Chart 21</div>
+      <div class="chart" id="chart22">Chart 22</div>
+      <div class="chart" id="chart23">Chart 23</div>
+      <div class="chart" id="chart24">Chart 24</div>
+      <div class="chart" id="chart25">Chart 25</div>
+      <div class="chart" id="chart26">Chart 26</div>
+      <div class="chart" id="chart27">Chart 27</div>
+      <div class="chart" id="chart28">Chart 28</div>
+      <div class="chart" id="chart29">Chart 29</div>
+      <div class="chart" id="chart30">Chart 30</div>
+      <div class="chart" id="chart31">Chart 31</div>
+      <div class="chart" id="chart32">Chart 32</div>
+      <div class="chart" id="chart33">Chart 33</div>
+      <div class="chart" id="chart34">Chart 34</div>
+      <div class="chart" id="chart35">Chart 35</div>
+      <div class="chart" id="chart36">Chart 36</div>
+      <div class="chart" id="chart37">Chart 37</div>
+      <div class="chart" id="chart38">Chart 38</div>
+      <div class="chart" id="chart39">Chart 39</div>
+      <div class="chart" id="chart40">Chart 40</div>
+      <div class="chart" id="chart41">Chart 41</div>
+      <div class="chart" id="chart42">Chart 42</div>
+      <div class="chart" id="chart43">Chart 43</div>
+      <div class="chart" id="chart44">Chart 44</div>
+      <div class="chart" id="chart45">Chart 45</div>
+      <div class="chart" id="chart46">Chart 46</div>
+      <div class="chart" id="chart47">Chart 47</div>
+      <div class="chart" id="chart48">Chart 48</div>
+
+      <div id="big-chart">Big Chart</div>
+    </div>
+
+    <button id="rotateBtn">Rotate + Merge</button>
+
+    <script>
+      const grid = document.getElementById('chartGrid');
+      const btn = document.getElementById('rotateBtn');
+      const bigChart = document.getElementById('big-chart');
+
+      let rotated = false;
+
+      btn.addEventListener('click', () => {
+        rotated = !rotated;
+
+        grid.classList.toggle('rotate', rotated);
+        grid.classList.toggle('tight', rotated);
+
+        btn.textContent = rotated ? 'Undo Merge' : 'Rotate + Merge';
+
+        if (rotated) {
+          // Delay fade-in until right before the rotation ends
+          setTimeout(() => {
+            bigChart.classList.add('show');
+          }, 650); // slightly before rotation finishes
+        } else {
+          // Instantly hide on reset
+          bigChart.classList.remove('show');
+        }
+      });
+    </script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/modules/series-label.js"></script>
+    <script src="https://code.highcharts.com/modules/accessibility.js"></script>
+    <script src="https://code.highcharts.com/themes/adaptive.js"></script>
+    <script src="charts/chart1.js"></script>
+    <script src="charts/chart2.js"></script>
+    <script src="charts/chart3.js"></script>
+    <script src="charts/chart4.js"></script>
+    <script src="charts/chart5.js"></script>
+    <script src="charts/chart6.js"></script>
+    <script src="charts/chart7.js"></script>
+    <script src="charts/chart8.js"></script>
+    <script src="charts/chart9.js"></script>
+    <script src="charts/chart10.js"></script>
+    <script src="charts/chart11.js"></script>
+    <script src="charts/chart12.js"></script>
+    <script src="charts/chart13.js"></script>
+    <script src="charts/chart14.js"></script>
+    <script src="charts/chart15.js"></script>
+    <script src="charts/chart16.js"></script>
+    <script src="charts/chart17.js"></script>
+    <script src="charts/chart18.js"></script>
+    <script src="charts/chart19.js"></script>
+    <script src="charts/chart20.js"></script>
+    <script src="charts/chart21.js"></script>
+    <script src="charts/chart22.js"></script>
+    <script src="charts/chart23.js"></script>
+    <script src="charts/chart24.js"></script>
+    <script src="charts/chart25.js"></script>
+    <script src="charts/chart26.js"></script>
+    <script src="charts/chart27.js"></script>
+    <script src="charts/chart28.js"></script>
+    <script src="charts/chart29.js"></script>
+    <script src="charts/chart30.js"></script>
+    <script src="charts/chart31.js"></script>
+    <script src="charts/chart32.js"></script>
+    <script src="charts/chart33.js"></script>
+    <script src="charts/chart34.js"></script>
+    <script src="charts/chart35.js"></script>
+    <script src="charts/chart36.js"></script>
+    <script src="charts/chart37.js"></script>
+    <script src="charts/chart38.js"></script>
+    <script src="charts/chart39.js"></script>
+    <script src="charts/chart40.js"></script>
+    <script src="charts/chart41.js"></script>
+    <script src="charts/chart42.js"></script>
+    <script src="charts/chart43.js"></script>
+    <script src="charts/chart44.js"></script>
+    <script src="charts/chart45.js"></script>
+    <script src="charts/chart46.js"></script>
+    <script src="charts/chart47.js"></script>
+    <script src="charts/chart48.js"></script>
+
+    <script src="bigchart.js"></script>
+
+  </body>
+
+</html>

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -16,7 +16,7 @@
 
       body {
         font-family: sans-serif;
-        background: #f5f5f5;
+        background: #0b1d51;
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -51,7 +51,7 @@
         font-size: 1.5rem;
         position: relative;
         z-index: 2;
-
+        outline: 2px solid #91a0ba;
       }
 
       #big-chart {

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -150,8 +150,7 @@
     </div>
 
     <button id="rotateBtn">Rotate + Merge</button>
-    <button id="moveOneBtn">Move Chart 49</button>
-    <button id="moveAllBtn">Move All Charts</button>
+    <button id="moveAllBtn">Move All + Merge</button>
 
     <script>
       const grid = document.getElementById('chartGrid');
@@ -244,19 +243,9 @@
 
 
       /*Sliding Squares*/
-      const chart49 = document.getElementById("chart49");
       const chartGrid = document.getElementById("chartGrid");
-      const moveOneBtn = document.getElementById('moveOneBtn');
       const moveAllBtn = document.getElementById('moveAllBtn');
 
-
-      moveOneBtn.addEventListener('click', () => {
-        const originalCol = squarePositions.chart49[0];
-        const originalRow = squarePositions.chart49[1];
-        const [newCol, newRow] = [squarePositions.chart49[2], squarePositions.chart49[3]];
-        console.log("Moving Chart 49");
-        moveChartTo(chart49, originalCol, originalRow, newCol, newRow);
-      });
 
       moveAllBtn.addEventListener('click', () => {
         console.log("Moving All Charts");

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -49,25 +49,9 @@
         align-items: center;
         justify-content: center;
         font-size: 1.5rem;
-        /* transition: transform 0.8s ease-in-out; */
-        /* transform-origin: center; */
         position: relative;
         z-index: 2;
 
-      }
-
-      .chart-inner {
-        width: 100%;
-        height: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        transition: transform 0.8s ease-in-out;
-        transform-origin: center;
-      }
-
-      .rotate .chart {
-        transform: rotate(90deg);
       }
 
       #big-chart {
@@ -110,156 +94,57 @@
   <body>
 
     <div class="grid" id="chartGrid">
-      <div class="chart" id="chart1">
-        <div class="chart-inner">Chart 1</div>
-      </div>
-      <div class="chart" id="chart2">
-        <div class="chart-inner">Chart 2</div>
-      </div>
-      <div class="chart" id="chart3">
-        <div class="chart-inner">Chart 3</div>
-      </div>
-      <div class="chart" id="chart4">
-        <div class="chart-inner">Chart 4</div>
-      </div>
-      <div class="chart" id="chart5">
-        <div class="chart-inner">Chart 5</div>
-      </div>
-      <div class="chart" id="chart6">
-        <div class="chart-inner">Chart 6</div>
-      </div>
-      <div class="chart" id="chart7">
-        <div class="chart-inner">Chart 7</div>
-      </div>
-      <div class="chart" id="chart8">
-        <div class="chart-inner">Chart 8</div>
-      </div>
-      <div class="chart" id="chart9">
-        <div class="chart-inner">Chart 9</div>
-      </div>
-      <div class="chart" id="chart10">
-        <div class="chart-inner">Chart 10</div>
-      </div>
-      <div class="chart" id="chart11">
-        <div class="chart-inner">Chart 11</div>
-      </div>
-      <div class="chart" id="chart12">
-        <div class="chart-inner">Chart 12</div>
-      </div>
-      <div class="chart" id="chart13">
-        <div class="chart-inner">Chart 13</div>
-      </div>
-      <div class="chart" id="chart14">
-        <div class="chart-inner">Chart 14</div>
-      </div>
-      <div class="chart" id="chart15">
-        <div class="chart-inner">Chart 15</div>
-      </div>
-      <div class="chart" id="chart16">
-        <div class="chart-inner">Chart 16</div>
-      </div>
-      <div class="chart" id="chart17">
-        <div class="chart-inner">Chart 17</div>
-      </div>
-      <div class="chart" id="chart18">
-        <div class="chart-inner">Chart 18</div>
-      </div>
-      <div class="chart" id="chart19">
-        <div class="chart-inner">Chart 19</div>
-      </div>
-      <div class="chart" id="chart20">
-        <div class="chart-inner">Chart 20</div>
-      </div>
-      <div class="chart" id="chart21">
-        <div class="chart-inner">chart 21</div>
-      </div>
-      <div class="chart" id="chart22">
-        <div class="chart-inner">chart 22</div>
-      </div>
-      <div class="chart" id="chart23">
-        <div class="chart-inner">chart 23</div>
-      </div>
-      <div class="chart" id="chart24">
-        <div class="chart-inner">chart 24</div>
-      </div>
-      <div class="chart" id="chart25">
-        <div class="chart-inner">chart 25</div>
-      </div>
-      <div class="chart" id="chart26">
-        <div class="chart-inner">chart 26</div>
-      </div>
-      <div class="chart" id="chart27">
-        <div class="chart-inner">chart 27</div>
-      </div>
-      <div class="chart" id="chart28">
-        <div class="chart-inner">Chart 28</div>
-      </div>
-      <div class="chart" id="chart29">
-        <div class="chart-inner">Chart 29</div>
-      </div>
-      <div class="chart" id="chart30">
-        <div class="chart-inner">Chart 30</div>
-      </div>
-      <div class="chart" id="chart31">
-        <div class="chart-inner">Chart 31</div>
-      </div>
-      <div class="chart" id="chart32">
-        <div class="chart-inner">Chart 32</div>
-      </div>
-      <div class="chart" id="chart33">
-        <div class="chart-inner">Chart 33</div>
-      </div>
-      <div class="chart" id="chart34">
-        <div class="chart-inner">Chart 34</div>
-      </div>
-      <div class="chart" id="chart35">
-        <div class="chart-inner">Chart 35</div>
-      </div>
-      <div class="chart" id="chart36">
-        <div class="chart-inner">Chart 36</div>
-      </div>
-      <div class="chart" id="chart37">
-        <div class="chart-inner">Chart 37</div>
-      </div>
-      <div class="chart" id="chart38">
-        <div class="chart-inner">Chart 38</div>
-      </div>
-      <div class="chart" id="chart39">
-        <div class="chart-inner">Chart 39</div>
-      </div>
-      <div class="chart" id="chart40">
-        <div class="chart-inner">Chart 40</div>
-      </div>
-      <div class="chart" id="chart41">
-        <div class="chart-inner">Chart 41</div>
-      </div>
-      <div class="chart" id="chart42">
-        <div class="chart-inner">Chart 42</div>
-      </div>
-      <div class="chart" id="chart43">
-        <div class="chart-inner">Chart 43</div>
-      </div>
-      <div class="chart" id="chart44">
-        <div class="chart-inner">Chart 44</div>
-      </div>
-      <div class="chart" id="chart45">
-        <div class="chart-inner">Chart 45</div>
-      </div>
-      <div class="chart" id="chart46">
-        <div class="chart-inner">Chart 46</div>
-      </div>
-      <div class="chart" id="chart47">
-        <div class="chart-inner">Chart 47</div>
-      </div>
-      <div class="chart" id="chart48">
-        <div class="chart-inner">Chart 48</div>
-      </div>
-      <div class="chart" id="chart49">
-        <div class="chart-inner">Chart 49</div>
-      </div>
-      <div class="chart" id="chart50">
-        <div class="chart-inner">Chart 50</div>
-      </div>
+      <div class="chart" id="chart1">Chart 1</div>
+      <div class="chart" id="chart2">Chart 2</div>
+      <div class="chart" id="chart3">Chart 3</div>
+      <div class="chart" id="chart4">Chart 4</div>
+      <div class="chart" id="chart5">Chart 5</div>
+      <div class="chart" id="chart6">Chart 6</div>
+      <div class="chart" id="chart7">Chart 7</div>
+      <div class="chart" id="chart8">Chart 8</div>
+      <div class="chart" id="chart9">Chart 9</div>
+      <div class="chart" id="chart10">Chart 10</div>
+      <div class="chart" id="chart11">Chart 11</div>
+      <div class="chart" id="chart12">Chart 12</div>
+      <div class="chart" id="chart13">Chart 13</div>
+      <div class="chart" id="chart14">Chart 14</div>
+      <div class="chart" id="chart15">Chart 15</div>
+      <div class="chart" id="chart16">Chart 16</div>
+      <div class="chart" id="chart17">Chart 17</div>
+      <div class="chart" id="chart18">Chart 18</div>
+      <div class="chart" id="chart19">Chart 19</div>
+      <div class="chart" id="chart20">Chart 20</div>
+      <div class="chart" id="chart21">Chart 21</div>
+      <div class="chart" id="chart22">Chart 22</div>
+      <div class="chart" id="chart23">Chart 23</div>
+      <div class="chart" id="chart24">Chart 24</div>
+      <div class="chart" id="chart25">Chart 25</div>
+      <div class="chart" id="chart26">Chart 26</div>
+      <div class="chart" id="chart27">Chart 27</div>
+      <div class="chart" id="chart28">Chart 28</div>
+      <div class="chart" id="chart29">Chart 29</div>
+      <div class="chart" id="chart30">Chart 30</div>
+      <div class="chart" id="chart31">Chart 31</div>
+      <div class="chart" id="chart32">Chart 32</div>
+      <div class="chart" id="chart33">Chart 33</div>
+      <div class="chart" id="chart34">Chart 34</div>
+      <div class="chart" id="chart35">Chart 35</div>
+      <div class="chart" id="chart36">Chart 36</div>
+      <div class="chart" id="chart37">Chart 37</div>
+      <div class="chart" id="chart38">Chart 38</div>
+      <div class="chart" id="chart39">Chart 39</div>
+      <div class="chart" id="chart40">Chart 40</div>
+      <div class="chart" id="chart41">Chart 41</div>
+      <div class="chart" id="chart42">Chart 42</div>
+      <div class="chart" id="chart43">Chart 43</div>
+      <div class="chart" id="chart44">Chart 44</div>
+      <div class="chart" id="chart45">Chart 45</div>
+      <div class="chart" id="chart46">Chart 46</div>
+      <div class="chart" id="chart47">Chart 47</div>
+      <div class="chart" id="chart48">Chart 48</div>
+      <div class="chart" id="chart49">Chart 49</div>
+      <div class="chart" id="chart50">Chart 50</div>
+
 
       <div id="big-chart">Big Chart</div>
     </div>
@@ -335,18 +220,24 @@
       rotateBtn.addEventListener('click', () => {
         rotated = !rotated;
 
-        grid.classList.toggle('rotate', rotated);
-        grid.classList.toggle('tight', rotated);
-
         rotateBtn.textContent = rotated ? 'Undo Merge' : 'Rotate + Merge';
 
+        const chartEls = document.querySelectorAll('.chart');
+
+        chartEls.forEach(chart => {
+          gsap.to(chart, {
+            rotate: rotated ? 90 : 0,
+            duration: 0.6,
+            ease: 'power2.inOut',
+          });
+        });
+
         if (rotated) {
-          // Delay fade-in until right before the rotation ends
+          // Delay fade-in of big chart slightly
           setTimeout(() => {
             bigChart.classList.add('show');
-          }, 650); // slightly before rotation finishes
+          }, 500); // slightly before rotation finishes
         } else {
-          // Instantly hide on reset
           bigChart.classList.remove('show');
         }
       });

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -167,7 +167,6 @@
     </div>
 
     <button id="rotateBtn">Rotate + Merge</button>
-    <button id="moveAllBtn">Move All + Merge</button>
 
     <script>
       const grid = document.getElementById('chartGrid');
@@ -257,69 +256,6 @@
           bigChart.classList.remove('show');
         }
       });
-
-
-      /*Sliding Squares*/
-      const chartGrid = document.getElementById("chartGrid");
-      const moveAllBtn = document.getElementById('moveAllBtn');
-
-
-      moveAllBtn.addEventListener('click', () => {
-        bigChart.classList.add('move')
-        console.log("Moving All Charts");
-
-        // Show the big chart with a short delay for smoothness
-        setTimeout(() => {
-          bigChart.classList.add('show');
-        }, 0.1); // match the animation delay
-
-        Object.keys(squarePositions).forEach(chartId => {
-          const chartEl = document.getElementById(chartId);
-          if (!chartEl) return;
-
-          const originalCol = squarePositions[chartId][0];
-          const originalRow = squarePositions[chartId][1];
-          const [newCol, newRow] = [squarePositions[chartId][2], squarePositions[chartId][3]];
-
-          moveChartTo(chartEl, originalCol, originalRow, newCol, newRow);
-        });
-      });
-
-      function moveChartTo(chartEl, fromCol, fromRow, toCol, toRow) {
-        const gridRect = chartGrid.getBoundingClientRect();
-        const chartRect = chartEl.getBoundingClientRect();
-
-        const currentLeft = chartRect.left - gridRect.left;
-        const currentTop = chartRect.top - gridRect.top;
-
-        const cellWidth = chartGrid.offsetWidth / 12;
-        const cellHeight = chartGrid.offsetHeight / 8;
-
-        const targetLeft = (toCol - 1) * cellWidth;
-        const targetTop = (toRow - 1) * cellHeight;
-
-        // Animate to target
-        gsap.to(chartEl, {
-          duration: 0.6,
-          x: targetLeft - currentLeft,
-          y: targetTop - currentTop,
-          ease: "power2.out",
-          onComplete: () => {
-            // Snap back into grid
-            chartEl.style.transition = "";
-            chartEl.style.transform = "";
-            chartEl.style.position = "";
-            chartEl.style.top = "";
-            chartEl.style.left = "";
-            chartEl.style.width = "";
-            chartEl.style.height = "";
-            chartEl.style.zIndex = "";
-
-            chartEl.style.gridColumnStart = toCol;
-            chartEl.style.gridRowStart = toRow;
-          }
-        });
-      }
 
 
     </script>

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -46,12 +46,21 @@
         align-items: center;
         justify-content: center;
         font-size: 1.5rem;
-        transition: transform 0.8s ease-in-out;
-        transform-origin: center;
+        /* transition: transform 0.8s ease-in-out; */
+        /* transform-origin: center; */
         position: relative;
         z-index: 2;
-        font-size: 0.9rem;
 
+      }
+
+      .chart-inner {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: transform 0.8s ease-in-out;
+        transform-origin: center;
       }
 
       .rotate .chart {
@@ -146,7 +155,9 @@
       <div class="chart" id="chart46">Chart 46</div>
       <div class="chart" id="chart47">Chart 47</div>
       <div class="chart" id="chart48">Chart 48</div>
-      <div class="chart" id="chart49">Chart 49</div>
+      <div class="chart" id="chart49">
+        <div class="chart-inner">Chart 49</div>
+      </div>
       <div class="chart" id="chart50">Chart 50</div>
 
       <div id="big-chart">Big Chart</div>
@@ -263,40 +274,12 @@
 
           const originalCol = squarePositions[chartId][0];
           const originalRow = squarePositions[chartId][1];
-          const newCol = squarePositions[chartId][2];
-          const newRow = squarePositions[chartId][3];
+          const [newCol, newRow] = [squarePositions[chartId][2], squarePositions[chartId][3]];
 
           moveChartTo(chartEl, originalCol, originalRow, newCol, newRow);
         });
       });
 
-      // function moveChartTo(chartEl, fromCol, fromRow, toCol, toRow) {
-      //   const gridRect = chartGrid.getBoundingClientRect();
-      //   const chartRect = chartEl.getBoundingClientRect();
-
-      //   const currentLeft = chartRect.left - gridRect.left;
-      //   const currentTop = chartRect.top - gridRect.top;
-
-      //   chartEl.style.position = "absolute";
-      //   chartEl.style.top = `${ currentTop }px`;
-      //   chartEl.style.left = `${ currentLeft }px`;
-      //   chartEl.style.width = `${ chartRect.width }px`;
-      //   chartEl.style.height = `${ chartRect.height }px`;
-      //   chartEl.style.gridColumnStart = "";
-      //   chartEl.style.gridRowStart = "";
-
-      //   const cellWidth = chartGrid.offsetWidth / 12;
-      //   const cellHeight = chartGrid.offsetHeight / 8;
-
-      //   const targetLeft = (toCol - 1) * cellWidth;
-      //   const targetTop = (toRow - 1) * cellHeight;
-
-      //   const dx = targetLeft - currentLeft;
-      //   const dy = targetTop - currentTop;
-
-      //   chartEl.style.transition = "transform 0.6s ease";
-      //   chartEl.style.transform = `translate(${ dx }px, ${ dy }px)`;
-      // }
       function moveChartTo(chartEl, fromCol, fromRow, toCol, toRow) {
         const gridRect = chartGrid.getBoundingClientRect();
         const chartRect = chartEl.getBoundingClientRect();

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -73,11 +73,11 @@
 
       #big-chart.move {
         position: absolute;
-        top: 30%;
+        top: 31%;
         left: 50%;
         transform: translate(-50%, -50%);
         /* perfect centering */
-        width: 83%;
+        width: 84%;
         height: 64%;
         aspect-ratio: 12/8;
         background: white;

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -93,60 +93,59 @@
 
   <body>
 
-    <div class="grid" id="chartGrid">
-      <div class="chart" id="chart1">Chart 1</div>
-      <div class="chart" id="chart2">Chart 2</div>
-      <div class="chart" id="chart3">Chart 3</div>
-      <div class="chart" id="chart4">Chart 4</div>
-      <div class="chart" id="chart5">Chart 5</div>
-      <div class="chart" id="chart6">Chart 6</div>
-      <div class="chart" id="chart7">Chart 7</div>
-      <div class="chart" id="chart8">Chart 8</div>
-      <div class="chart" id="chart9">Chart 9</div>
-      <div class="chart" id="chart10">Chart 10</div>
-      <div class="chart" id="chart11">Chart 11</div>
-      <div class="chart" id="chart12">Chart 12</div>
-      <div class="chart" id="chart13">Chart 13</div>
-      <div class="chart" id="chart14">Chart 14</div>
-      <div class="chart" id="chart15">Chart 15</div>
-      <div class="chart" id="chart16">Chart 16</div>
-      <div class="chart" id="chart17">Chart 17</div>
-      <div class="chart" id="chart18">Chart 18</div>
-      <div class="chart" id="chart19">Chart 19</div>
-      <div class="chart" id="chart20">Chart 20</div>
-      <div class="chart" id="chart21">Chart 21</div>
-      <div class="chart" id="chart22">Chart 22</div>
-      <div class="chart" id="chart23">Chart 23</div>
-      <div class="chart" id="chart24">Chart 24</div>
-      <div class="chart" id="chart25">Chart 25</div>
-      <div class="chart" id="chart26">Chart 26</div>
-      <div class="chart" id="chart27">Chart 27</div>
-      <div class="chart" id="chart28">Chart 28</div>
-      <div class="chart" id="chart29">Chart 29</div>
-      <div class="chart" id="chart30">Chart 30</div>
-      <div class="chart" id="chart31">Chart 31</div>
-      <div class="chart" id="chart32">Chart 32</div>
-      <div class="chart" id="chart33">Chart 33</div>
-      <div class="chart" id="chart34">Chart 34</div>
-      <div class="chart" id="chart35">Chart 35</div>
-      <div class="chart" id="chart36">Chart 36</div>
-      <div class="chart" id="chart37">Chart 37</div>
-      <div class="chart" id="chart38">Chart 38</div>
-      <div class="chart" id="chart39">Chart 39</div>
-      <div class="chart" id="chart40">Chart 40</div>
-      <div class="chart" id="chart41">Chart 41</div>
-      <div class="chart" id="chart42">Chart 42</div>
-      <div class="chart" id="chart43">Chart 43</div>
-      <div class="chart" id="chart44">Chart 44</div>
-      <div class="chart" id="chart45">Chart 45</div>
-      <div class="chart" id="chart46">Chart 46</div>
-      <div class="chart" id="chart47">Chart 47</div>
-      <div class="chart" id="chart48">Chart 48</div>
-      <div class="chart" id="chart49">Chart 49</div>
-      <div class="chart" id="chart50">Chart 50</div>
-
-
-      <div id="big-chart">Big Chart</div>
+      <div class="grid" id="chartGrid">
+        <div class="chart" id="chart1">Chart 1</div>
+        <div class="chart" id="chart2">Chart 2</div>
+        <div class="chart" id="chart3">Chart 3</div>
+        <div class="chart" id="chart4">Chart 4</div>
+        <div class="chart" id="chart5">Chart 5</div>
+        <div class="chart" id="chart6">Chart 6</div>
+        <div class="chart" id="chart7">Chart 7</div>
+        <div class="chart" id="chart8">Chart 8</div>
+        <div class="chart" id="chart9">Chart 9</div>
+        <div class="chart" id="chart10">Chart 10</div>
+        <div class="chart" id="chart11">Chart 11</div>
+        <div class="chart" id="chart12">Chart 12</div>
+        <div class="chart" id="chart13">Chart 13</div>
+        <div class="chart" id="chart14">Chart 14</div>
+        <div class="chart" id="chart15">Chart 15</div>
+        <div class="chart" id="chart16">Chart 16</div>
+        <div class="chart" id="chart17">Chart 17</div>
+        <div class="chart" id="chart18">Chart 18</div>
+        <div class="chart" id="chart19">Chart 19</div>
+        <div class="chart" id="chart20">Chart 20</div>
+        <div class="chart" id="chart21">Chart 21</div>
+        <div class="chart" id="chart22">Chart 22</div>
+        <div class="chart" id="chart23">Chart 23</div>
+        <div class="chart" id="chart24">Chart 24</div>
+        <div class="chart" id="chart25">Chart 25</div>
+        <div class="chart" id="chart26">Chart 26</div>
+        <div class="chart" id="chart27">Chart 27</div>
+        <div class="chart" id="chart28">Chart 28</div>
+        <div class="chart" id="chart29">Chart 29</div>
+        <div class="chart" id="chart30">Chart 30</div>
+        <div class="chart" id="chart31">Chart 31</div>
+        <div class="chart" id="chart32">Chart 32</div>
+        <div class="chart" id="chart33">Chart 33</div>
+        <div class="chart" id="chart34">Chart 34</div>
+        <div class="chart" id="chart35">Chart 35</div>
+        <div class="chart" id="chart36">Chart 36</div>
+        <div class="chart" id="chart37">Chart 37</div>
+        <div class="chart" id="chart38">Chart 38</div>
+        <div class="chart" id="chart39">Chart 39</div>
+        <div class="chart" id="chart40">Chart 40</div>
+        <div class="chart" id="chart41">Chart 41</div>
+        <div class="chart" id="chart42">Chart 42</div>
+        <div class="chart" id="chart43">Chart 43</div>
+        <div class="chart" id="chart44">Chart 44</div>
+        <div class="chart" id="chart45">Chart 45</div>
+        <div class="chart" id="chart46">Chart 46</div>
+        <div class="chart" id="chart47">Chart 47</div>
+        <div class="chart" id="chart48">Chart 48</div>
+        <div class="chart" id="chart49">Chart 49</div>
+        <div class="chart" id="chart50">Chart 50</div>
+        <div id="big-chart">Big Chart</div>
+      </div>
     </div>
 
     <button id="rotateBtn">Rotate + Merge</button>
@@ -254,7 +253,7 @@
         setTimeout(() => {
           bigChart.classList.add('show');
         }, 500); // match the animation delay
-        
+
         Object.keys(squarePositions).forEach(chartId => {
           const chartEl = document.getElementById(chartId);
           if (!chartEl) return;

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -36,10 +36,10 @@
         gap: 0;
       }
 
+
       .chart {
         width: 100%;
         aspect-ratio: 1/1;
-        ;
         background: #fff;
         color: white;
         display: flex;
@@ -153,21 +153,80 @@
     </div>
 
     <button id="rotateBtn">Rotate + Merge</button>
+    <button id="moveOneBtn">Move Chart 49</button>
+    <button id="moveAllBtn">Move All Charts</button>
 
     <script>
       const grid = document.getElementById('chartGrid');
-      const btn = document.getElementById('rotateBtn');
+      const rotateBtn = document.getElementById('rotateBtn');
       const bigChart = document.getElementById('big-chart');
 
       let rotated = false;
 
-      btn.addEventListener('click', () => {
+      const squarePositions = {
+        "chart1": [12, 1, 8, 1],
+        "chart2": [12, 2, 9, 1],
+        "chart3": [12, 3, 10, 1],
+        "chart4": [11, 2, 11, 1],
+        "chart5": [11, 3, 11, 2],
+        "chart6": [11, 4, 10, 3],
+        "chart7": [11, 5, 11, 3],
+        "chart8": [10, 3, 10, 2],
+        "chart9": [10, 4, 9, 3],
+        "chart10": [10, 5, 11, 4],
+        "chart11": [10, 6, 10, 5],
+        "chart12": [10, 8, 11, 5],
+        "chart13": [9, 4, 9, 2],
+        "chart14": [9, 5, 10, 4],
+        "chart15": [9, 6, 9, 5],
+        "chart16": [9, 7, 8, 5],
+        "chart17": [8, 3, 8, 2],
+        "chart18": [8, 4, 8, 3],
+        "chart19": [8, 5, 9, 4],
+        "chart20": [8, 6, 8, 4],
+        "chart21": [8, 7, 7, 4],
+        "chart22": [7, 4, 7, 1],
+        "chart23": [7, 5, 7, 2],
+        "chart24": [7, 6, 7, 3],
+        "chart25": [7, 7, 6, 5],
+        "chart26": [6, 3, 6, 1],
+        "chart27": [6, 4, 6, 2],
+        "chart28": [6, 5, 6, 3],
+        "chart29": [6, 6, 6, 4],
+        "chart30": [6, 7, 5, 5],
+        "chart31": [5, 3, 5, 1],
+        "chart32": [5, 4, 5, 2],
+        "chart33": [5, 5, 5, 3],
+        "chart34": [5, 6, 5, 4],
+        "chart35": [5, 7, 4, 5],
+        "chart36": [5, 8, 7, 5],
+        "chart37": [4, 3, 4, 1],
+        "chart38": [4, 4, 4, 2],
+        "chart39": [4, 5, 4, 3],
+        "chart40": [4, 6, 4, 4],
+        "chart41": [4, 7, 3, 5],
+        "chart42": [3, 3, 3, 1],
+        "chart43": [3, 4, 3, 2],
+        "chart44": [3, 5, 3, 3],
+        "chart45": [3, 6, 3, 4],
+        "chart46": [2, 3, 2, 2],
+        "chart47": [2, 4, 2, 3],
+        "chart48": [2, 5, 2, 4],
+        "chart49": [1, 1, 2, 1],
+        "chart50": [1, 7, 2, 5]
+      }
+
+      const [originalCol, originalRow] = squarePositions["chart49"];
+      console.log(originalCol, originalRow);
+
+
+      rotateBtn.addEventListener('click', () => {
         rotated = !rotated;
 
         grid.classList.toggle('rotate', rotated);
         grid.classList.toggle('tight', rotated);
 
-        btn.textContent = rotated ? 'Undo Merge' : 'Rotate + Merge';
+        rotateBtn.textContent = rotated ? 'Undo Merge' : 'Rotate + Merge';
 
         if (rotated) {
           // Delay fade-in until right before the rotation ends
@@ -179,6 +238,109 @@
           bigChart.classList.remove('show');
         }
       });
+
+
+      /*Sliding Squares*/
+      const chart49 = document.getElementById("chart49");
+      const chartGrid = document.getElementById("chartGrid");
+      const moveOneBtn = document.getElementById('moveOneBtn');
+      const moveAllBtn = document.getElementById('moveAllBtn');
+
+
+      moveOneBtn.addEventListener('click', () => {
+        const originalCol = squarePositions.chart49[0];
+        const originalRow = squarePositions.chart49[1];
+        const [newCol, newRow] = [squarePositions.chart49[2], squarePositions.chart49[3]];
+        console.log("Moving Chart 49");
+        moveChartTo(chart49, originalCol, originalRow, newCol, newRow);
+      });
+
+      moveAllBtn.addEventListener('click', () => {
+        console.log("Moving All Charts");
+        Object.keys(squarePositions).forEach(chartId => {
+          const chartEl = document.getElementById(chartId);
+          if (!chartEl) return;
+
+          const originalCol = squarePositions[chartId][0];
+          const originalRow = squarePositions[chartId][1];
+          const newCol = squarePositions[chartId][2];
+          const newRow = squarePositions[chartId][3];
+
+          moveChartTo(chartEl, originalCol, originalRow, newCol, newRow);
+        });
+      });
+
+      // function moveChartTo(chartEl, fromCol, fromRow, toCol, toRow) {
+      //   const gridRect = chartGrid.getBoundingClientRect();
+      //   const chartRect = chartEl.getBoundingClientRect();
+
+      //   const currentLeft = chartRect.left - gridRect.left;
+      //   const currentTop = chartRect.top - gridRect.top;
+
+      //   chartEl.style.position = "absolute";
+      //   chartEl.style.top = `${ currentTop }px`;
+      //   chartEl.style.left = `${ currentLeft }px`;
+      //   chartEl.style.width = `${ chartRect.width }px`;
+      //   chartEl.style.height = `${ chartRect.height }px`;
+      //   chartEl.style.gridColumnStart = "";
+      //   chartEl.style.gridRowStart = "";
+
+      //   const cellWidth = chartGrid.offsetWidth / 12;
+      //   const cellHeight = chartGrid.offsetHeight / 8;
+
+      //   const targetLeft = (toCol - 1) * cellWidth;
+      //   const targetTop = (toRow - 1) * cellHeight;
+
+      //   const dx = targetLeft - currentLeft;
+      //   const dy = targetTop - currentTop;
+
+      //   chartEl.style.transition = "transform 0.6s ease";
+      //   chartEl.style.transform = `translate(${ dx }px, ${ dy }px)`;
+      // }
+      function moveChartTo(chartEl, fromCol, fromRow, toCol, toRow) {
+        const gridRect = chartGrid.getBoundingClientRect();
+        const chartRect = chartEl.getBoundingClientRect();
+
+        const currentLeft = chartRect.left - gridRect.left;
+        const currentTop = chartRect.top - gridRect.top;
+
+        const cellWidth = chartGrid.offsetWidth / 12;
+        const cellHeight = chartGrid.offsetHeight / 8;
+
+        const targetLeft = (toCol - 1) * cellWidth;
+        const targetTop = (toRow - 1) * cellHeight;
+
+        const dx = targetLeft - currentLeft;
+        const dy = targetTop - currentTop;
+
+        // Fix position temporarily
+        chartEl.style.position = "absolute";
+        chartEl.style.top = `${ currentTop }px`;
+        chartEl.style.left = `${ currentLeft }px`;
+        chartEl.style.width = `${ chartRect.width }px`;
+        chartEl.style.height = `${ chartRect.height }px`;
+        chartEl.style.transition = "transform 0.6s ease";
+        chartEl.style.zIndex = 10; // Make sure it's above others while animating
+
+        // Animate movement
+        chartEl.style.transform = `translate(${ dx }px, ${ dy }px)`;
+
+        // After animation, snap back into grid
+        setTimeout(() => {
+          chartEl.style.transition = "";
+          chartEl.style.transform = "";
+          chartEl.style.position = "";
+          chartEl.style.top = "";
+          chartEl.style.left = "";
+          chartEl.style.width = "";
+          chartEl.style.height = "";
+          chartEl.style.zIndex = "";
+
+          chartEl.style.gridColumnStart = toCol;
+          chartEl.style.gridRowStart = toRow;
+        }, 650); // match transition duration
+      }
+
     </script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/modules/series-label.js"></script>
@@ -235,8 +397,6 @@
     <script src="charts/chart49.js"></script>
     <script src="charts/chart50.js"></script>
     <script src="charts/bigChart.js"></script>
-
-    <script src="bigchart.js"></script>
 
   </body>
 

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -51,7 +51,6 @@
         font-size: 1.5rem;
         position: relative;
         z-index: 2;
-        outline: 2px solid #91a0ba;
       }
 
       #big-chart {
@@ -97,9 +96,8 @@
         visibility: visible;
         opacity: 1;
         pointer-events: auto;
-        transition: opacity 0.5s ease-in-out;
+        transition: opacity 0.3s ease-in-out;
         z-index: 2;
-        outline: 1px solid red;
       }
 
       button {
@@ -254,7 +252,7 @@
           // Delay fade-in of big chart slightly
           setTimeout(() => {
             bigChart.classList.add('show');
-          }, 500); // slightly before rotation finishes
+          }, 250); // slightly before rotation finishes
         } else {
           bigChart.classList.remove('show');
         }

--- a/misc-examples/national-small-multiples/index.html
+++ b/misc-examples/national-small-multiples/index.html
@@ -62,7 +62,6 @@
         height: 100%;
         aspect-ratio: 12/8;
         background: white;
-        border: 2px solid #ccc;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -72,6 +71,27 @@
         transition: opacity 0.2s ease-in-out, visibility 0s linear 0.2s;
         z-index: 1;
       }
+
+      #big-chart.move {
+        position: absolute;
+        top: 30%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        /* perfect centering */
+        width: 83%;
+        height: 64%;
+        aspect-ratio: 12/8;
+        background: white;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        visibility: hidden;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s ease-in-out, visibility 0s linear 0.2s;
+        z-index: 1;
+      }
+      
 
       #big-chart.show {
         visibility: visible;
@@ -93,59 +113,59 @@
 
   <body>
 
-      <div class="grid" id="chartGrid">
-        <div class="chart" id="chart1">Chart 1</div>
-        <div class="chart" id="chart2">Chart 2</div>
-        <div class="chart" id="chart3">Chart 3</div>
-        <div class="chart" id="chart4">Chart 4</div>
-        <div class="chart" id="chart5">Chart 5</div>
-        <div class="chart" id="chart6">Chart 6</div>
-        <div class="chart" id="chart7">Chart 7</div>
-        <div class="chart" id="chart8">Chart 8</div>
-        <div class="chart" id="chart9">Chart 9</div>
-        <div class="chart" id="chart10">Chart 10</div>
-        <div class="chart" id="chart11">Chart 11</div>
-        <div class="chart" id="chart12">Chart 12</div>
-        <div class="chart" id="chart13">Chart 13</div>
-        <div class="chart" id="chart14">Chart 14</div>
-        <div class="chart" id="chart15">Chart 15</div>
-        <div class="chart" id="chart16">Chart 16</div>
-        <div class="chart" id="chart17">Chart 17</div>
-        <div class="chart" id="chart18">Chart 18</div>
-        <div class="chart" id="chart19">Chart 19</div>
-        <div class="chart" id="chart20">Chart 20</div>
-        <div class="chart" id="chart21">Chart 21</div>
-        <div class="chart" id="chart22">Chart 22</div>
-        <div class="chart" id="chart23">Chart 23</div>
-        <div class="chart" id="chart24">Chart 24</div>
-        <div class="chart" id="chart25">Chart 25</div>
-        <div class="chart" id="chart26">Chart 26</div>
-        <div class="chart" id="chart27">Chart 27</div>
-        <div class="chart" id="chart28">Chart 28</div>
-        <div class="chart" id="chart29">Chart 29</div>
-        <div class="chart" id="chart30">Chart 30</div>
-        <div class="chart" id="chart31">Chart 31</div>
-        <div class="chart" id="chart32">Chart 32</div>
-        <div class="chart" id="chart33">Chart 33</div>
-        <div class="chart" id="chart34">Chart 34</div>
-        <div class="chart" id="chart35">Chart 35</div>
-        <div class="chart" id="chart36">Chart 36</div>
-        <div class="chart" id="chart37">Chart 37</div>
-        <div class="chart" id="chart38">Chart 38</div>
-        <div class="chart" id="chart39">Chart 39</div>
-        <div class="chart" id="chart40">Chart 40</div>
-        <div class="chart" id="chart41">Chart 41</div>
-        <div class="chart" id="chart42">Chart 42</div>
-        <div class="chart" id="chart43">Chart 43</div>
-        <div class="chart" id="chart44">Chart 44</div>
-        <div class="chart" id="chart45">Chart 45</div>
-        <div class="chart" id="chart46">Chart 46</div>
-        <div class="chart" id="chart47">Chart 47</div>
-        <div class="chart" id="chart48">Chart 48</div>
-        <div class="chart" id="chart49">Chart 49</div>
-        <div class="chart" id="chart50">Chart 50</div>
-        <div id="big-chart">Big Chart</div>
-      </div>
+    <div class="grid" id="chartGrid">
+      <div class="chart" id="chart1">Chart 1</div>
+      <div class="chart" id="chart2">Chart 2</div>
+      <div class="chart" id="chart3">Chart 3</div>
+      <div class="chart" id="chart4">Chart 4</div>
+      <div class="chart" id="chart5">Chart 5</div>
+      <div class="chart" id="chart6">Chart 6</div>
+      <div class="chart" id="chart7">Chart 7</div>
+      <div class="chart" id="chart8">Chart 8</div>
+      <div class="chart" id="chart9">Chart 9</div>
+      <div class="chart" id="chart10">Chart 10</div>
+      <div class="chart" id="chart11">Chart 11</div>
+      <div class="chart" id="chart12">Chart 12</div>
+      <div class="chart" id="chart13">Chart 13</div>
+      <div class="chart" id="chart14">Chart 14</div>
+      <div class="chart" id="chart15">Chart 15</div>
+      <div class="chart" id="chart16">Chart 16</div>
+      <div class="chart" id="chart17">Chart 17</div>
+      <div class="chart" id="chart18">Chart 18</div>
+      <div class="chart" id="chart19">Chart 19</div>
+      <div class="chart" id="chart20">Chart 20</div>
+      <div class="chart" id="chart21">Chart 21</div>
+      <div class="chart" id="chart22">Chart 22</div>
+      <div class="chart" id="chart23">Chart 23</div>
+      <div class="chart" id="chart24">Chart 24</div>
+      <div class="chart" id="chart25">Chart 25</div>
+      <div class="chart" id="chart26">Chart 26</div>
+      <div class="chart" id="chart27">Chart 27</div>
+      <div class="chart" id="chart28">Chart 28</div>
+      <div class="chart" id="chart29">Chart 29</div>
+      <div class="chart" id="chart30">Chart 30</div>
+      <div class="chart" id="chart31">Chart 31</div>
+      <div class="chart" id="chart32">Chart 32</div>
+      <div class="chart" id="chart33">Chart 33</div>
+      <div class="chart" id="chart34">Chart 34</div>
+      <div class="chart" id="chart35">Chart 35</div>
+      <div class="chart" id="chart36">Chart 36</div>
+      <div class="chart" id="chart37">Chart 37</div>
+      <div class="chart" id="chart38">Chart 38</div>
+      <div class="chart" id="chart39">Chart 39</div>
+      <div class="chart" id="chart40">Chart 40</div>
+      <div class="chart" id="chart41">Chart 41</div>
+      <div class="chart" id="chart42">Chart 42</div>
+      <div class="chart" id="chart43">Chart 43</div>
+      <div class="chart" id="chart44">Chart 44</div>
+      <div class="chart" id="chart45">Chart 45</div>
+      <div class="chart" id="chart46">Chart 46</div>
+      <div class="chart" id="chart47">Chart 47</div>
+      <div class="chart" id="chart48">Chart 48</div>
+      <div class="chart" id="chart49">Chart 49</div>
+      <div class="chart" id="chart50">Chart 50</div>
+      <div id="big-chart">Big Chart</div>
+    </div>
     </div>
 
     <button id="rotateBtn">Rotate + Merge</button>
@@ -247,6 +267,7 @@
 
 
       moveAllBtn.addEventListener('click', () => {
+        bigChart.classList.add('move')
         console.log("Moving All Charts");
 
         // Show the big chart with a short delay for smoothness

--- a/misc-examples/national-small-multiples/national-squares.css
+++ b/misc-examples/national-small-multiples/national-squares.css
@@ -1,0 +1,347 @@
+/* ------------------------------------------------------ */
+/*                  Column 12: ME, NH, RI                 */
+/* ------------------------------------------------------ */
+
+/*MAINE*/
+#chart1 {
+  grid-column: 12;
+  grid-row: 1;
+}
+
+/*NEW HAMPSHIRE*/
+#chart2 {
+  grid-column: 12;
+  grid-row: 2;
+}
+
+/*RHODE ISLAND*/
+#chart3 {
+  grid-column: 12;
+  grid-row: 3;
+}
+
+/* ------------------------------------------------------ */
+/*                Column 11: VT, MA, CT, DE               */
+/* ------------------------------------------------------ */
+
+/*VERMONT*/
+#chart4 {
+  grid-column: 11;
+  grid-row: 2;
+}
+
+/* MASSACHUSETTS */
+#chart5 {
+  grid-column: 11;
+  grid-row: 3;
+}
+
+/* CONNECTICUT */
+#chart6 {
+  grid-column: 11;
+  grid-row: 4;
+}
+
+/* DELAWARE */
+#chart7 {
+  grid-column: 11;
+  grid-row: 5;
+}
+
+/* ------------------------------------------------------ */
+/*              Column 10: NY, NJ, MD, NC, FL             */
+/* ------------------------------------------------------ */
+
+/* New York */
+#chart8 {
+  grid-column: 10;
+  grid-row: 3;
+}
+
+/* New Jersey */
+#chart9 {
+  grid-column: 10;
+  grid-row: 4;
+}
+
+/* Maryland */
+#chart10 {
+  grid-column: 10;
+  grid-row: 5;
+}
+
+/* North Carolina */
+#chart11 {
+  grid-column: 10;
+  grid-row: 6;
+}
+
+/* Florida */
+#chart12 {
+  grid-column: 10;
+  grid-row: 8;
+}
+
+/* ------------------------------------------------------ */
+/*                Column 9: PA, VA, SC, GA                */
+/* ------------------------------------------------------ */
+
+/* Pennsylvania */
+#chart13 {
+  grid-column: 9;
+  grid-row: 4;
+}
+
+/* Virginia */
+#chart14{
+  grid-column: 9;
+  grid-row: 5;
+}
+
+/* South Carolina */
+#chart15 {
+  grid-column: 9;
+  grid-row: 6;
+}
+
+/* Georgia */
+#chart16 {
+  grid-column: 9;
+  grid-row: 7;
+}
+
+
+/* ------------------------------------------------------ */
+/*              Column 8: MI, OH, WV, TN, AL              */
+/* ------------------------------------------------------ */
+
+/* Michigan */
+#chart17 {
+  grid-column: 8;
+  grid-row: 3;
+}
+
+/* Ohio */
+#chart18 {
+  grid-column: 8;
+  grid-row: 4;
+}
+
+/* West Virginia */
+#chart19 {
+  grid-column: 8;
+  grid-row: 5;
+}
+
+/* Tennessee */
+#chart20 {
+  grid-column: 8;
+  grid-row: 6;
+}
+
+/* Alabama */
+#chart21 {
+  grid-column: 8;
+  grid-row: 7;
+}
+
+/* ------------------------------------------------------ */
+/*                Column 7: WI, IN, KY, MS                */
+/* ------------------------------------------------------ */
+/* Wisconsin */
+#chart22 {
+  grid-column: 7;
+  grid-row: 4;
+}
+
+/* Indiana */
+#chart23 {
+  grid-column: 7;
+  grid-row: 5;
+}
+
+/* Kentucky */
+#chart24 {
+  grid-column: 7;
+  grid-row: 6;
+}
+
+/* Mississippi */
+#chart25 {
+  grid-column: 7;
+  grid-row: 7;
+}
+
+/* ------------------------------------------------------ */
+/*              Column 6: MN, IA, IL, MO, AR              */
+/* ------------------------------------------------------ */
+
+/* Minnesota */
+#chart26 {
+  grid-column: 6;
+  grid-row: 3;
+}
+
+/* Iowa */
+#chart27 {
+  grid-column: 6;
+  grid-row: 4;
+}
+
+/* Illinois */
+#chart28 {
+  grid-column: 6;
+  grid-row: 5;
+}
+
+/* Missouri */
+#chart29 {
+  grid-column: 6;
+  grid-row: 6;
+}
+
+/* Arkansas */
+#chart30 {
+  grid-column: 6;
+  grid-row: 7;
+}
+
+/* ------------------------------------------------------ */
+/*            Column 5: ND, SD, NE, JS, LA, TX            */
+/* ------------------------------------------------------ */
+
+/* North Dakota */
+#chart31 {
+  grid-column: 5;
+  grid-row: 3;
+}
+
+/* South Dakota */
+#chart32 {
+  grid-column: 5;
+  grid-row: 4;
+}
+
+/* Nebraska */
+#chart33 {
+  grid-column: 5;
+  grid-row: 5;
+}
+
+/* Kansas */
+#chart34 {
+  grid-column: 5;
+  grid-row: 6;
+}
+
+/* Louisiana */
+#chart35 {
+  grid-column: 5;
+  grid-row: 7;
+}
+
+/* Texas */
+#chart36 {
+  grid-column: 5;
+  grid-row: 8;
+}
+
+/* ------------------------------------------------------ */
+/*              Column 4: MT, WY, CO, NM, OK              */
+/* ------------------------------------------------------ */
+
+/* Montana */
+#chart37 {
+  grid-column: 4;
+  grid-row: 3;
+}
+
+/* Wyoming */
+#chart38 {
+  grid-column: 4;
+  grid-row: 4;
+}
+
+/* Colorado */
+#chart39 {
+  grid-column: 4;
+  grid-row: 5;
+}
+
+/* New Mexico */
+#chart40 {
+  grid-column: 4;
+  grid-row: 6;
+}
+
+/* Oklahoma */
+#chart41 {
+  grid-column: 4;
+  grid-row: 7;
+}
+
+/* ------------------------------------------------------ */
+/*                Column 3: ID, UT, NV, AZ                */
+/* ------------------------------------------------------ */
+
+/* Idaho */
+#chart42 {
+  grid-column: 3;
+  grid-row: 3;
+}
+
+/* Utah */
+#chart43 {
+  grid-column: 3;
+  grid-row: 4;
+}
+
+/* Nevada */
+#chart44 {
+  grid-column: 3;
+  grid-row: 5;
+}
+
+/* Arizona */
+#chart45 {
+  grid-column: 3;
+  grid-row: 6;
+}
+
+/* ------------------------------------------------------ */
+/*                  Column 2: WA, OR, CA                  */
+/* ------------------------------------------------------ */
+
+/* Washington */
+#chart46 {
+  grid-column: 2;
+  grid-row: 3;
+}
+
+/* Oregon */
+#chart47 {
+  grid-column: 2;
+  grid-row: 4;
+}
+
+/* California */
+#chart48 {
+  grid-column: 2;
+  grid-row: 5;
+}
+
+/* ------------------------------------------------------ */
+/*                    Column 1: AK, HI                    */
+/* ------------------------------------------------------ */
+
+/* Alaska */
+#chart49 {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+/* Hawaii */
+#chart50 {
+  grid-column: 1;
+  grid-row: 7;
+}


### PR DESCRIPTION
Demo of idea for interactive small multiples of US States that rotate and merge into a single chart that would reflect national data. This is in vanilla html/css/js and the charts are the Highcharts [line chart demo](https://www.highcharts.com/demo/highcharts/line-chart), just stylized for the example. I just copied the data into 51 js files (one for each state + national). This is obviously not a production/smart way to do it, but because the charts were all the same it was fastest and I was most interested in figuring out the rotation/merge functionality. 

https://github.com/user-attachments/assets/b5b948e2-db76-4331-a329-6e675cbde82f

Prior code in this branch had a Move All and Merge where instead of rotating, the states combine to form a smaller national graph. I  didn't figure out undoing the merge back to the national view, but that may be an option worth doing eventually. 

https://github.com/user-attachments/assets/28d8655e-25a3-4d83-aaa9-9d0ad5e305e3

Another to-do would be figuring out the tooltip, probably using something like [Tippy.js](https://atomiks.github.io/tippyjs/). Right now the tooltips are all inside their own charts and not visible because of the space. We could also take the tooltip/info out to the side, like I did in this [critical minerals](https://mariel-delagarza.github.io/critical-minerals/) project. 

For things like this on mobile, the horizontal scroll or stacking the grid and its info makes more sense than trying to squish the entire thing down to 300px wide. That critical minerals project was a good exercise in making that work. 

